### PR TITLE
Use spellchecker library to determine real words

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+certifi==2021.10.8
+charset-normalizer==2.0.10
+click==8.0.3
+Flask==2.0.2
+gunicorn==20.1.0
+idna==3.3
+itsdangerous==2.0.1
+Jinja2==3.0.3
+MarkupSafe==2.0.1
+pyspellchecker==0.6.3
+requests==2.27.1
+urllib3==1.26.8
+Werkzeug==2.0.2


### PR DESCRIPTION
Before this commit we would need to reach out to the Webster Dictionary
API to determine if a word was real or not. This added additional
latency to the request for checking and is subject to rate limiting
depending on how their api is implemented.

In order to remove that dependency this commit adds in the use of a
spellchecker library which has a decent dictionary that is local which
can be used to determine if a word is actually a word or not.

This commit also removes the use of a hard-coded private API key which
should be avoided when committing to a public repo.